### PR TITLE
fix: consolidate CORS handling and proxy health check to Rails

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,7 +1,8 @@
 
+# CORSはここ（Rack::Cors）で一元管理する。nginxではCORSヘッダーを付与しないこと。
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins_list = ENV.fetch("CORS_ORIGINS", "localhost:3000,https://logi-quiz.com").split(",").map(&:strip)
+    origins_list = ENV.fetch("CORS_ORIGINS", "http://localhost:3000,https://logi-quiz.com").split(",").map(&:strip)
     origins(*origins_list)
 
     resource "*",

--- a/backend/nginx/nginx.conf
+++ b/backend/nginx/nginx.conf
@@ -12,11 +12,11 @@ http {
         listen 80;
         server_name _;
 
-        # ALBヘルスチェック用エンドポイント
-        location /health {
+        # ALBヘルスチェック: Railsまで疎通させ、アプリの生死を反映する
+        location = /health {
             access_log off;
-            return 200 'healthy';
-            add_header Content-Type text/plain;
+            proxy_pass http://rails_app;
+            proxy_set_header Host $host;
         }
 
         location / {
@@ -31,11 +31,6 @@ http {
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
-
-            # CORS設定
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization' always;
-            add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
     }
 }


### PR DESCRIPTION
Closes #91

## 変更内容（3秒で読める要約）

CORS定義をnginxとRack::Corsの2箇所からRack::Corsに一元化。ALBヘルスチェック(`/health`)をnginxの静的200からRailsまでproxyするよう変更し、アプリの生死を正しく反映するようにした。

## 確認方法

- [x] `bundle exec rspec` 77 examples, 0 failures
- [x] `curl -i -X OPTIONS .../sections -H "Origin: http://localhost:3000" ...` で `access-control-allow-origin` が重複なく1回返る
- [x] `docker build backend/nginx/` → `nginx -t` がsyntax ok
- [x] `/health` が200を返す（nginx経由・Rails直後とも確認）