### PR TITLE
perf: optimize quizzes sampling, add auth rate limiting and DB constraints

### DIFF
--- a/backend/app/controllers/quizzes_controller.rb
+++ b/backend/app/controllers/quizzes_controller.rb
@@ -2,13 +2,12 @@
 class QuizzesController < ApplicationController
   # GET /sections/:section_id/quizzes
   # 指定セクションからランダムに10問を選択肢・解説付きで返却
-  # includes: N+1クエリ防止、sample: DB非依存のランダム選択
+  # IDのみを先にsampleし、当選した10問だけをeager loadする（全件ロード回避）
   def index
     section = Section.find(params[:section_id])
-    quizzes = section.questions
-                     .includes(:choices, :explanation)
-                     .to_a
-                     .sample(10)
+    question_ids = section.questions.pluck(:id).sample(10)
+    quizzes = Question.where(id: question_ids)
+                      .includes(:choices, :explanation)
 
     render json: quizzes.as_json(
       only: [:id, :question_text],

--- a/backend/config/initializers/rack_attack.rb
+++ b/backend/config/initializers/rack_attack.rb
@@ -1,3 +1,26 @@
-Rack::Attack.throttle('admin/analytics', limit: 10, period: 60) do |req|
-  req.ip if req.path.start_with?('/admin/analytics')
+# APIレート制限
+# 認証系はブルートフォース対策、analyticsは重いクエリの乱用防止
+class Rack::Attack
+  # コンテナ単位のインメモリストア（タスク1つ運用のため十分。スケールアウト時はRedisへ）
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  # ログイン試行: 同一IPから 5回/20秒
+  throttle("auth/sign_in/ip", limit: 5, period: 20.seconds) do |req|
+    req.ip if req.path == "/auth/sign_in" && req.post?
+  end
+
+  # アカウント登録: 同一IPから 5回/5分
+  throttle("auth/sign_up/ip", limit: 5, period: 5.minutes) do |req|
+    req.ip if req.path == "/auth" && req.post?
+  end
+
+  # パスワードリセット要求: 同一IPから 5回/15分
+  throttle("auth/password/ip", limit: 5, period: 15.minutes) do |req|
+    req.ip if req.path == "/auth/password" && req.post?
+  end
+
+  # BI分析ダッシュボード: 同一IPから 10回/分
+  throttle("admin/analytics", limit: 10, period: 60) do |req|
+    req.ip if req.path.start_with?("/admin/analytics")
+  end
 end

--- a/backend/db/migrate/20260704020907_add_dashboard_index_and_tighten_constraints.rb
+++ b/backend/db/migrate/20260704020907_add_dashboard_index_and_tighten_constraints.rb
@@ -1,0 +1,15 @@
+class AddDashboardIndexAndTightenConstraints < ActiveRecord::Migration[7.0]
+  def change
+    # ダッシュボードの「直近クリア10件」クエリ用
+    add_index :user_sections, [:user_id, :cleared_at]
+
+    # 孤児レコードをDBレベルで防止
+    change_column_null :questions, :section_id, false
+    change_column_null :choices, :question_id, false
+    change_column_null :explanations, :question_id, false
+
+    # is_correct は必ず true/false を持つ
+    change_column_default :choices, :is_correct, from: nil, to: false
+    change_column_null :choices, :is_correct, false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_25_000001) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_04_020907) do
   create_table "choices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "question_id"
+    t.bigint "question_id", null: false
     t.string "choice_text"
-    t.boolean "is_correct"
+    t.boolean "is_correct", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["question_id"], name: "index_choices_on_question_id"
   end
 
   create_table "explanations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "question_id"
+    t.bigint "question_id", null: false
     t.text "explanation_text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -46,7 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_25_000001) do
   end
 
   create_table "questions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "section_id"
+    t.bigint "section_id", null: false
     t.text "question_text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -97,6 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_25_000001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["section_id"], name: "index_user_sections_on_section_id"
+    t.index ["user_id", "cleared_at"], name: "index_user_sections_on_user_id_and_cleared_at"
     t.index ["user_id"], name: "index_user_sections_on_user_id"
   end
 

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -80,6 +80,10 @@ RSpec.configure do |config|
 
   config.before(:suite) { truncate_all_tables }
 
+  # Rack::Attackはデフォルトで無効化する（rack_attack_specでのみ明示的に有効化する）。
+  # スロットリングを有効にしたまま実行すると、他のスペックの連続リクエストが誤って制限される。
+  config.before(:suite) { Rack::Attack.enabled = false }
+
   config.before(:each, type: :request) do
     host! 'localhost'
   end

--- a/backend/spec/requests/quizzes_spec.rb
+++ b/backend/spec/requests/quizzes_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe "Quizzes", type: :request do
       expect(quiz).to include("explanation")
     end
   end
+
+  describe "GET /index セクションに11問以上ある場合" do
+    let!(:section) { create(:section) }
+    let!(:questions) { create_list(:question, 15, section: section) }
+
+    before { get "/sections/#{section.id}/quizzes" }
+
+    it "10問のみ返す" do
+      body = JSON.parse(response.body)
+      expect(body.size).to eq(10)
+      expect(body.first).to include("choices", "explanation")
+    end
+  end
 end

--- a/backend/spec/requests/rack_attack_spec.rb
+++ b/backend/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Rack::Attack", type: :request do
+  before do
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  after { Rack::Attack.enabled = false }
+
+  describe "POST /auth/sign_in" do
+    it "同一IPからの連続リクエストを制限する" do
+      6.times do
+        post "/auth/sign_in", params: { email: "a@example.com", password: "wrong" }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "POST /auth/password" do
+    it "パスワードリセット要求を制限する" do
+      6.times do
+        post "/auth/password", params: { email: "a@example.com", redirect_url: "http://localhost:3000" }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+end


### PR DESCRIPTION
Closes #93

## 変更内容（3秒で読める要約）

quizzes#indexのメモリロードを改善、認証エンドポイントへのRack::Attackスロットリングを追加（既存のanalyticsスロットルがNullStoreで無効化されていた問題も合わせて修正）、DBに複合インデックス+NOT NULL制約を追加。

## 確認方法

- [x] `bundle exec rspec` 80 examples, 0 failures
- [x] 11問以上のセクションで `GET /sections/:id/quizzes` が10問のみ返す（リグレッションテスト追加）
- [x] `/auth/sign_in` への6回連続POSTで429が返る（リクエストスペック追加）
- [x] `rails db:migrate` → `db:rollback` → `db:migrate` を3回連続実行してエラーなし
- [x] 事前に孤児レコード・NULLレコードが0件であることを確認済み

## 実装中の計画変更

- Task 11は当初「初期化ファイル内で`Rails.env.test?`によりテスト時にRack::Attackを無効化」する想定だったが機能しなかった（後述の理由）。代わりに`spec/rails_helper.rb`に`config.before(:suite) { Rack::Attack.enabled = false }`を追加し、rack_attack_specでのみ明示的に有効化する方式に変更。
- 副次的な発見: この環境では`docker-compose.yml`の`RAILS_ENV: ${RAILS_ENV:-development}`がコンテナ環境変数として先に設定されるため、`bundle exec rspec`実行時に`rails_helper.rb`の`ENV['RAILS_ENV'] ||= 'test'`が効かず、実質development環境（`api_development`DB）でテストが走っている。明示的に`RAILS_ENV=test`を指定すると`config/environments/test.rb`が`localhost`をhost allowlistに含んでいないため全リクエストスペックが失敗する（既存の別バグ）。これは今回のスコープ外だが別issue化を推奨する。