### PR TITLE
feat: multi-stage Dockerfile and remove sleep-based DB wait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,7 @@ setup:
 		echo "Created .env from .env.example"; \
 	fi
 	@make build
-	@make up
-	@echo "Waiting for DB to be ready..."
-	@sleep 10
+	docker compose up -d --wait
 	@make db-setup
 	@echo ""
 	@echo "Setup complete!"
@@ -62,7 +60,7 @@ build:
 # ===========================================
 
 up:
-	docker compose up -d
+	docker compose up -d --wait
 	@echo ""
 	@echo "Services started:"
 	@echo "  Frontend: http://localhost:3000"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -112,3 +112,6 @@ yarn-debug.log*
 
 # クイズデータ（ビジネスデータのため非公開）
 /db/seeds/quiz_data.json
+
+# deploy.sh が生成するタスク定義（AWSアカウントID・Secrets ARNを含む）
+/ecs/task-definition.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,33 +1,64 @@
-FROM ruby:3.2.2
+# syntax=docker/dockerfile:1
 
-RUN apt-get update && apt-get install -y default-mysql-client curl && \
+# ---- 共通ベース（ランタイム依存のみ）----
+FROM ruby:3.2.2-slim AS base
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends default-mysql-client curl tzdata && \
     rm -rf /var/lib/apt/lists/*
+
+ENV RAILS_LOG_TO_STDOUT=true
+WORKDIR /api
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+# ---- production 用 gem ビルド ----
+FROM base AS build
 
 ARG RUBYGEMS_VERSION=3.4.6
 
-ENV RAILS_ENV=production
-ENV RAILS_LOG_TO_STDOUT=true
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends build-essential default-libmysqlclient-dev git && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /api
-WORKDIR /api
-
-COPY Gemfile /api/Gemfile
-COPY Gemfile.lock /api/Gemfile.lock
-
+COPY Gemfile Gemfile.lock ./
 RUN gem update --system ${RUBYGEMS_VERSION} && \
     bundle config set --local without 'development test' && \
-    bundle install
+    bundle install && \
+    rm -rf /usr/local/bundle/cache
 
-COPY . /api
+# ---- 開発・テスト用（docker-compose が使用）----
+FROM base AS dev
 
-# ヘルスチェック
+ARG RUBYGEMS_VERSION=3.4.6
+ENV RAILS_ENV=development
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends build-essential default-libmysqlclient-dev git && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY Gemfile Gemfile.lock ./
+RUN gem update --system ${RUBYGEMS_VERSION} && bundle install
+
+CMD ["rails", "server", "-b", "0.0.0.0"]
+
+# ---- 本番用（ECS デプロイが使用、最終ステージ = docker build のデフォルト）----
+FROM base AS prod
+
+ENV RAILS_ENV=production
+
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY . .
+
+RUN useradd rails --create-home --shell /usr/sbin/nologin && \
+    mkdir -p /api/tmp/pids /api/log /api/storage && \
+    chown -R rails:rails /api/tmp /api/log /api/storage
+USER rails
+
 HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
   CMD curl -f http://localhost:3000/health || exit 1
-
-COPY entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
-
-EXPOSE 3000
 
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,9 +4,8 @@ set -e
 # PIDファイルの削除
 rm -f /api/tmp/pids/server.pid
 
-# 本番環境でのデータベースマイグレーション（オプション）
-# if [ "$RAILS_ENV" = "production" ]; then
-#   bundle exec rails db:migrate
-# fi
+# NOTE: 本番のDBマイグレーションはここでは実行しない。
+# 複数タスクの同時起動でmigrateが競合するため、
+# デプロイパイプラインの one-off ECS タスクで実行する（別issueで対応）。
 
 exec "$@"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,6 +5,8 @@
 
 services:
   api:
+    build:
+      target: dev
     command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - ./backend:/api:cached


### PR DESCRIPTION
Closes #95

## 変更内容（3秒で読める要約）

`backend/Dockerfile`をbase/build/dev/prodの多段構成に変更し、開発環境にdev/test gemを含めつつ本番イメージを軽量化・non-root化。`Makefile`の`sleep 10`を`docker compose up -d --wait`に置き換え。

## 確認方法

- [x] `docker compose build api` → `docker compose up -d --wait api db` → `bundle exec rspec` 80 examples, 0 failures
- [x] `docker build --target prod -t logi-quiz-api-prod-test backend/` 成功、`docker run --rm ... whoami` が `rails`（non-root）
- [x] イメージサイズ: 約1GB → 388MB
- [x] `make db-setup` がsleepなしで正常完了（DB healthcheck経由）
- [x] `git check-ignore backend/ecs/task-definition.json` がパスを返す