### PR TITLE
docs: document manual deploy procedure and .env.deploy usage

### DIFF
--- a/backend/.env.deploy.example
+++ b/backend/.env.deploy.example
@@ -1,3 +1,7 @@
+# NOTE: このファイルは scripts/deploy.sh による手動デプロイ用の設定テンプレート。
+# GitHub Actions等のCI/CDは未導入のため、本番デプロイは現時点でこの手順のみ。
+# 使い方: cp backend/.env.deploy.example backend/.env.deploy して値を埋める
+
 # AWS設定
 AWS_ACCOUNT_ID=123456789012
 AWS_REGION=ap-northeast-1

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,30 @@
+# logi-quiz API (Rails)
 
+For local development setup, see [../LOCAL_SETUP.md](../LOCAL_SETUP.md).
+
+## Deployment
+
+There is currently no CI/CD pipeline (see [issue #89](https://github.com/SomaTomita/logi-quiz/issues/89)). Production deploys are done manually via `scripts/deploy.sh`, which builds and pushes the `rails` and `nginx` images to ECR, registers a new ECS task definition, and updates the ECS service.
+
+```bash
+cp backend/.env.deploy.example backend/.env.deploy   # first time only, then fill in real values
+cd backend
+./scripts/deploy.sh          # build + push both images, register task definition, update service
+./scripts/deploy.sh rails    # rebuild/push only the rails image
+./scripts/deploy.sh deploy   # force a new deployment of the current task definition (no rebuild)
+```
+
+Run `./scripts/deploy.sh help` for the full command list.
+
+### Database migrations
+
+Migrations are **not** run automatically on deploy. `entrypoint.sh` intentionally skips `db:migrate` (running it from every task at boot would race across concurrently starting containers). Run migrations manually against the target database before or after deploying:
+
+```bash
+DATABASE_HOST=<rds-host> DATABASE_USERNAME=<user> DATABASE_PASSWORD=<pass> DATABASE_NAME=<db> \
+  RAILS_ENV=production bundle exec rails db:migrate
+```
+
+### Rollback
+
+**Known limitation:** images are pushed to ECR under the `:latest` tag only. Re-registering an older ECS task definition revision does *not* get you back the old code, since that revision still resolves to whatever `:latest` currently points to in ECR. A real rollback today requires manually re-tagging a previous image digest as `:latest` in ECR before forcing a new deployment. Moving to immutable per-deploy tags (e.g. git SHA) is tracked separately.


### PR DESCRIPTION
Closes #97

## 変更内容（3秒で読める要約）

空だった`backend/README.md`に手動デプロイ手順（`scripts/deploy.sh`）・マイグレーション手順・ロールバックの既知の制限を追記。`.env.deploy.example`にも手動デプロイ専用である旨の注記を追加。

## 確認方法

- [x] ルートの`.env.example`が`docker-compose*.yml`参照変数を全て網羅していることを確認済み（変更なし）
- [x] `backend/README.md`を読めばデプロイ手順とロールバックの制約が分かる