### PR TITLE
fix: prevent bundle exec rspec from silently running against dev DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ bash-front:
 	docker compose exec front sh
 
 test:
-	docker compose exec api bundle exec rspec
+	docker compose exec -e RAILS_ENV=test api bundle exec rspec
 
 lint:
 	docker compose exec api bundle exec rubocop

--- a/backend/config/environments/test.rb
+++ b/backend/config/environments/test.rb
@@ -61,4 +61,7 @@ Rails.application.configure do
 
   # Allow requests from www.example.com (default Rails test host)
   config.hosts << "www.example.com"
+
+  # spec/rails_helper.rbのhost! 'localhost'に対応するため許可する
+  config.hosts << "localhost"
 end


### PR DESCRIPTION
Closes #103

## 変更内容（3秒で読める要約）

`docker-compose.yml`のRAILS_ENV=developmentがコンテナ環境変数として先に確定するため`bundle exec rspec`が実際にはdevelopment DBに対して実行され、テーブルがtruncateされていた（実際に発生を確認済み）。`Makefile`の`test`ターゲットに`-e RAILS_ENV=test`を明示指定し、`test.rb`の`config.hosts`にも`localhost`を追加して解消。

## 確認方法

- [x] `make test`が`api_test`DBに対して80 examples, 0 failuresで完了
- [x] `make test`実行後もdevelopment DBのシードデータ（20セクション・21ユーザー）が保持されている
- [x] `make lint` / `/health`（200）に影響なし