### PR TITLE
fix: add retry resilience to frontend yarn install for registry flakiness (#106)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,11 @@ ENV CI=true
 COPY ./app/package.json ./app/yarn.lock ./
 
 # 依存関係をインストール（lockfileに厳密に従う）
-RUN yarn install --frozen-lockfile
+# npmレジストリの一時的な取りこぼし（esbuildのoptionalDependencies解決失敗など）で
+# Yarn Classicが即座にハードフェイルすることがあるため、リトライを入れる
+RUN yarn install --frozen-lockfile --network-timeout 600000 \
+  || yarn install --frozen-lockfile --network-timeout 600000 \
+  || yarn install --frozen-lockfile --network-timeout 600000
 
 # アプリケーションコードをコピー
 COPY ./app .


### PR DESCRIPTION
Closes #106

## 変更内容（3秒で読める要約）

frontend/Dockerfile の `yarn install --frozen-lockfile` が npmレジストリの一時的な取りこぼしでハードフェイルしていたため、最大3回リトライ+network-timeout延長を追加した。

## 確認方法

- [x] `docker build --no-cache -t logi-quiz-frontend-test frontend/` が成功する