### PR TITLE
feat: Terraform IaC skeleton for AWS multi-env infrastructure (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ Thumbs.db
 frontend/app/test-results/
 frontend/app/playwright-report/
 
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log
+
 frontend/app/src/features/auth/types.ts
 frontend/app/src/features/home/pages/HomePage.tsx
 frontend/app/src/features/quiz/components/QuizResult.tsx

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,5 @@
+# Terraform
+
+logi-quiz インフラのTerraform管理コード。詳細は `docs/plans/2026-07-04-terraform-aws-multi-env-infrastructure.md` を参照。
+
+<!-- Task 27（ドキュメント更新）で本文を追記する -->

--- a/terraform/bootstrap/.terraform.lock.hcl
+++ b/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,55 @@
+# tfstate保存用S3バケット。このスタック自体のstateはローカル管理
+# （ここで作るバケットが存在しないと他スタックのbackendが初期化できないため）。
+
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  bucket_name = "logi-quiz-tfstate-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = local.bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket                  = aws_s3_bucket.tfstate.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+output "state_bucket" {
+  value = aws_s3_bucket.tfstate.bucket
+}

--- a/terraform/envs/production/.terraform.lock.hcl
+++ b/terraform/envs/production/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/terraform/envs/production/backend.tf
+++ b/terraform/envs/production/backend.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "logi-quiz-tfstate-438656921478"
+    key          = "envs/production/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+
+  default_tags {
+    tags = {
+      Project     = "logi-quiz"
+      Environment = "production"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# CloudFront証明書用（us-east-1必須）
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project     = "logi-quiz"
+      Environment = "production"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/terraform/envs/production/main.tf
+++ b/terraform/envs/production/main.tf
@@ -1,0 +1,108 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  name_prefix = "logi-quiz-production"
+  region      = "ap-northeast-1"
+  zone_name   = "logi-quiz.com"
+
+  ecr_repository_url = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${local.region}.amazonaws.com/logi-quiz-api"
+  image              = "${local.ecr_repository_url}:${var.image_tag}"
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  name_prefix                  = local.name_prefix
+  db_maintenance_ingress_cidrs = var.db_maintenance_ingress_cidrs
+}
+
+module "rds" {
+  source = "../../modules/rds"
+
+  name_prefix         = local.name_prefix
+  subnet_ids          = module.network.public_subnet_ids
+  security_group_id   = module.network.rds_security_group_id
+  db_name             = var.db_name
+  publicly_accessible = var.rds_publicly_accessible
+
+  # production: バックアップ7日 / 削除保護 / 最終スナップショットあり（module defaults）
+}
+
+module "app_secrets" {
+  source = "../../modules/app_secrets"
+
+  name_prefix = local.name_prefix
+}
+
+module "alb_api" {
+  source = "../../modules/alb_api"
+
+  name_prefix       = local.name_prefix
+  vpc_id            = module.network.vpc_id
+  subnet_ids        = module.network.public_subnet_ids
+  security_group_id = module.network.alb_security_group_id
+  api_domain_name   = "api.logi-quiz.com"
+  route53_zone_name = local.zone_name
+  enable_dns_record = var.enable_dns_records
+}
+
+module "ecs" {
+  source = "../../modules/ecs_service"
+
+  name_prefix       = local.name_prefix
+  region            = local.region
+  image             = local.image
+  cpu               = "512"
+  memory            = "1024"
+  desired_count     = var.desired_count
+  use_fargate_spot  = false
+  subnet_ids        = module.network.public_subnet_ids
+  security_group_id = module.network.app_security_group_id
+  target_group_arn  = module.alb_api.target_group_arn
+
+  container_env = {
+    RAILS_ENV           = "production"
+    RAILS_LOG_TO_STDOUT = "true"
+    DATABASE_HOST       = module.rds.address
+    DATABASE_NAME       = module.rds.db_name
+    DATABASE_USERNAME   = module.rds.master_username
+    DATABASE_PORT       = "3306"
+    ALLOWED_HOSTS       = var.allowed_hosts
+    CORS_ORIGINS        = var.cors_origins
+    MAILER_HOST         = var.mailer_host
+    EMAIL_ADDRESS       = var.email_address
+    SMTP_ADDRESS        = var.smtp_address
+    SMTP_PORT           = var.smtp_port
+    SMTP_DOMAIN         = var.smtp_domain
+    SMTP_USERNAME       = var.smtp_username
+  }
+
+  container_secrets = [
+    { name = "DATABASE_PASSWORD", valueFrom = module.rds.db_password_secret_arn },
+    { name = "SECRET_KEY_BASE", valueFrom = module.app_secrets.secret_key_base_arn },
+    { name = "EMAIL_PASSWORD", valueFrom = module.app_secrets.email_password_arn },
+  ]
+
+  secret_arns = [
+    module.rds.db_password_secret_arn,
+    module.app_secrets.secret_key_base_arn,
+    module.app_secrets.email_password_arn,
+  ]
+
+  depends_on = [module.alb_api]
+}
+
+module "frontend" {
+  source = "../../modules/frontend"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  name_prefix       = "${local.name_prefix}-frontend"
+  bucket_name       = "logi-quiz-frontend-production-${data.aws_caller_identity.current.account_id}"
+  domain_name       = "logi-quiz.com"
+  route53_zone_name = local.zone_name
+  enable_dns_record = var.enable_dns_records
+}

--- a/terraform/envs/production/outputs.tf
+++ b/terraform/envs/production/outputs.tf
@@ -1,0 +1,63 @@
+output "alb_dns_name" {
+  value = module.alb_api.alb_dns_name
+}
+
+output "rds_address" {
+  value = module.rds.address
+}
+
+output "rds_password_secret_arn" {
+  value = module.rds.db_password_secret_arn
+}
+
+output "rds_db_name" {
+  value = module.rds.db_name
+}
+
+output "rds_master_username" {
+  value = module.rds.master_username
+}
+
+output "secret_key_base_arn" {
+  value = module.app_secrets.secret_key_base_arn
+}
+
+output "email_password_arn" {
+  value = module.app_secrets.email_password_arn
+}
+
+output "ecs_cluster_name" {
+  value = module.ecs.cluster_name
+}
+
+output "ecs_service_name" {
+  value = module.ecs.service_name
+}
+
+output "api_task_family" {
+  value = module.ecs.api_task_family
+}
+
+output "migrate_task_family" {
+  value = module.ecs.migrate_task_family
+}
+
+output "ecs_subnet_ids" {
+  value = module.network.public_subnet_ids
+}
+
+output "ecs_security_group_id" {
+  value = module.network.app_security_group_id
+}
+
+output "frontend_bucket_name" {
+  value = module.frontend.bucket_name
+}
+
+output "cloudfront_distribution_id" {
+  value = module.frontend.distribution_id
+}
+
+output "cloudfront_domain_name" {
+  value = module.frontend.distribution_domain_name
+}

--- a/terraform/envs/production/terraform.tfvars
+++ b/terraform/envs/production/terraform.tfvars
@@ -1,0 +1,19 @@
+# ---- カットオーバー制御（Task 19〜23で段階的に変更する）----
+desired_count      = 0     # Task 22でDB移行完了後に1へ
+enable_dns_records = false # Task 23のカットオーバーでtrueへ
+
+# ---- アプリ設定 ----
+# NOTE: このAWSアカウントには現行の手動構築インフラ（ECSクラスター等）が存在しないため、
+# DATABASE_NAME/MAILER_HOSTはTask 2相当の確認ができていない。Rails慣習に基づく暫定値。
+# 実際にレガシー環境がある場合はTask 2の棚卸し結果で上書きすること。
+db_name       = "logi_quiz_production"
+allowed_hosts = "api.logi-quiz.com"
+cors_origins  = "https://logi-quiz.com"
+mailer_host   = "api.logi-quiz.com"
+
+# ---- メール（Amazon SES。Gmail SMTPから移行）----
+email_address = "no-reply@logi-quiz.com" # SESで検証済みのドメインのアドレス
+smtp_address  = "email-smtp.ap-northeast-1.amazonaws.com"
+smtp_port     = "587"
+smtp_domain   = "logi-quiz.com"
+smtp_username = "<terraform -chdir=../../global output -raw ses_smtp_username の値（global apply後に取得）>"

--- a/terraform/envs/production/variables.tf
+++ b/terraform/envs/production/variables.tf
@@ -1,0 +1,64 @@
+variable "image_tag" {
+  description = "初回apply用イメージタグ。以降のデプロイはGHA管理"
+  type        = string
+  default     = "latest"
+}
+
+variable "desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "enable_dns_records" {
+  description = "カットオーバースイッチ。trueでapi/frontのDNSを新スタックへ向ける"
+  type        = bool
+  default     = false
+}
+
+variable "rds_publicly_accessible" {
+  description = "DB移行作業時のみtrue"
+  type        = bool
+  default     = false
+}
+
+variable "db_maintenance_ingress_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "db_name" {
+  type = string
+}
+
+variable "allowed_hosts" {
+  type = string
+}
+
+variable "cors_origins" {
+  type = string
+}
+
+variable "mailer_host" {
+  type = string
+}
+
+variable "email_address" {
+  type = string
+}
+
+variable "smtp_address" {
+  type = string
+}
+
+variable "smtp_port" {
+  type = string
+}
+
+variable "smtp_domain" {
+  type = string
+}
+
+variable "smtp_username" {
+  description = "SES SMTPユーザー名（globalスタックの ses_smtp_username 出力。アクセスキーIDなので非シークレット扱い）"
+  type        = string
+}

--- a/terraform/envs/staging/.terraform.lock.hcl
+++ b/terraform/envs/staging/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/terraform/envs/staging/backend.tf
+++ b/terraform/envs/staging/backend.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "logi-quiz-tfstate-438656921478"
+    key          = "envs/staging/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-1"
+
+  default_tags {
+    tags = {
+      Project     = "logi-quiz"
+      Environment = "staging"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# CloudFront証明書用（us-east-1必須。stagingのリージョンに関わらず変更不要）
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project     = "logi-quiz"
+      Environment = "staging"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -1,0 +1,116 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  name_prefix = "logi-quiz-staging"
+  region      = "ap-southeast-1" # productionと異なりシンガポール
+  zone_name   = "logi-quiz.com"  # Route53はリージョンに関わらずグローバル
+
+  # ECR・SESはglobalスタック（東京）に一本化されているため、
+  # イメージURLは local.region ではなく東京を明示する
+  ecr_repository_url = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-1.amazonaws.com/logi-quiz-api"
+  image              = "${local.ecr_repository_url}:${var.image_tag}"
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  name_prefix                  = local.name_prefix
+  availability_zones           = ["ap-southeast-1a", "ap-southeast-1b"]
+  db_maintenance_ingress_cidrs = var.db_maintenance_ingress_cidrs
+}
+
+module "rds" {
+  source = "../../modules/rds"
+
+  name_prefix         = local.name_prefix
+  subnet_ids          = module.network.public_subnet_ids
+  security_group_id   = module.network.rds_security_group_id
+  db_name             = var.db_name
+  publicly_accessible = var.rds_publicly_accessible
+
+  instance_class                   = "db.t4g.micro"
+  backup_retention_period          = 0 # stagingはシードで再生成可能なためバックアップ不要
+  skip_final_snapshot              = true
+  deletion_protection              = false
+  password_recovery_window_in_days = 0 # destroy→再applyでSecret名が衝突しないように
+}
+
+module "app_secrets" {
+  source = "../../modules/app_secrets"
+
+  name_prefix             = local.name_prefix
+  recovery_window_in_days = 0 # destroy→再applyで名前衝突しないよう即時削除
+}
+
+module "alb_api" {
+  source = "../../modules/alb_api"
+
+  name_prefix       = local.name_prefix
+  vpc_id            = module.network.vpc_id
+  subnet_ids        = module.network.public_subnet_ids
+  security_group_id = module.network.alb_security_group_id
+  api_domain_name   = "staging-api.logi-quiz.com"
+  route53_zone_name = local.zone_name
+  enable_dns_record = var.enable_dns_records
+}
+
+module "ecs" {
+  source = "../../modules/ecs_service"
+
+  name_prefix       = local.name_prefix
+  region            = local.region
+  image             = local.image
+  cpu               = "256"
+  memory            = "512"
+  desired_count     = var.desired_count
+  use_fargate_spot  = true # 中断されても問題ないためSpotでコスト最小化
+  subnet_ids        = module.network.public_subnet_ids
+  security_group_id = module.network.app_security_group_id
+  target_group_arn  = module.alb_api.target_group_arn
+
+  container_env = {
+    RAILS_ENV           = "production"
+    RAILS_LOG_TO_STDOUT = "true"
+    DATABASE_HOST       = module.rds.address
+    DATABASE_NAME       = module.rds.db_name
+    DATABASE_USERNAME   = module.rds.master_username
+    DATABASE_PORT       = "3306"
+    ALLOWED_HOSTS       = var.allowed_hosts
+    CORS_ORIGINS        = var.cors_origins
+    MAILER_HOST         = var.mailer_host
+    EMAIL_ADDRESS       = var.email_address
+    SMTP_ADDRESS        = var.smtp_address
+    SMTP_PORT           = var.smtp_port
+    SMTP_DOMAIN         = var.smtp_domain
+    SMTP_USERNAME       = var.smtp_username
+  }
+
+  container_secrets = [
+    { name = "DATABASE_PASSWORD", valueFrom = module.rds.db_password_secret_arn },
+    { name = "SECRET_KEY_BASE", valueFrom = module.app_secrets.secret_key_base_arn },
+    { name = "EMAIL_PASSWORD", valueFrom = module.app_secrets.email_password_arn },
+  ]
+
+  secret_arns = [
+    module.rds.db_password_secret_arn,
+    module.app_secrets.secret_key_base_arn,
+    module.app_secrets.email_password_arn,
+  ]
+
+  depends_on = [module.alb_api]
+}
+
+module "frontend" {
+  source = "../../modules/frontend"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  name_prefix       = "${local.name_prefix}-frontend"
+  bucket_name       = "logi-quiz-frontend-staging-${data.aws_caller_identity.current.account_id}"
+  domain_name       = "staging.logi-quiz.com"
+  route53_zone_name = local.zone_name
+  enable_dns_record = var.enable_dns_records
+}

--- a/terraform/envs/staging/outputs.tf
+++ b/terraform/envs/staging/outputs.tf
@@ -1,0 +1,63 @@
+output "alb_dns_name" {
+  value = module.alb_api.alb_dns_name
+}
+
+output "rds_address" {
+  value = module.rds.address
+}
+
+output "rds_password_secret_arn" {
+  value = module.rds.db_password_secret_arn
+}
+
+output "rds_db_name" {
+  value = module.rds.db_name
+}
+
+output "rds_master_username" {
+  value = module.rds.master_username
+}
+
+output "secret_key_base_arn" {
+  value = module.app_secrets.secret_key_base_arn
+}
+
+output "email_password_arn" {
+  value = module.app_secrets.email_password_arn
+}
+
+output "ecs_cluster_name" {
+  value = module.ecs.cluster_name
+}
+
+output "ecs_service_name" {
+  value = module.ecs.service_name
+}
+
+output "api_task_family" {
+  value = module.ecs.api_task_family
+}
+
+output "migrate_task_family" {
+  value = module.ecs.migrate_task_family
+}
+
+output "ecs_subnet_ids" {
+  value = module.network.public_subnet_ids
+}
+
+output "ecs_security_group_id" {
+  value = module.network.app_security_group_id
+}
+
+output "frontend_bucket_name" {
+  value = module.frontend.bucket_name
+}
+
+output "cloudfront_distribution_id" {
+  value = module.frontend.distribution_id
+}
+
+output "cloudfront_domain_name" {
+  value = module.frontend.distribution_domain_name
+}

--- a/terraform/envs/staging/terraform.tfvars
+++ b/terraform/envs/staging/terraform.tfvars
@@ -1,0 +1,15 @@
+# stagingはオンデマンド構築のため最初からDNS有効・タスク1で作る
+desired_count      = 1
+enable_dns_records = true
+
+db_name       = "api_staging"
+allowed_hosts = "staging-api.logi-quiz.com"
+cors_origins  = "https://staging.logi-quiz.com"
+mailer_host   = "staging-api.logi-quiz.com"
+
+# メールはproductionと同じSES（ドメインID・SMTPユーザーはglobalスタック共用、東京リージョン固定）
+email_address = "no-reply@logi-quiz.com"
+smtp_address  = "email-smtp.ap-northeast-1.amazonaws.com"
+smtp_port     = "587"
+smtp_domain   = "logi-quiz.com"
+smtp_username = "<terraform -chdir=../../global output -raw ses_smtp_username の値（global apply後に取得）>"

--- a/terraform/envs/staging/variables.tf
+++ b/terraform/envs/staging/variables.tf
@@ -1,0 +1,64 @@
+variable "image_tag" {
+  description = "初回apply用イメージタグ。以降のデプロイはGHA管理"
+  type        = string
+  default     = "latest"
+}
+
+variable "desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "enable_dns_records" {
+  description = "カットオーバースイッチ。trueでapi/frontのDNSを新スタックへ向ける"
+  type        = bool
+  default     = false
+}
+
+variable "rds_publicly_accessible" {
+  description = "DB移行作業時のみtrue"
+  type        = bool
+  default     = false
+}
+
+variable "db_maintenance_ingress_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "db_name" {
+  type = string
+}
+
+variable "allowed_hosts" {
+  type = string
+}
+
+variable "cors_origins" {
+  type = string
+}
+
+variable "mailer_host" {
+  type = string
+}
+
+variable "email_address" {
+  type = string
+}
+
+variable "smtp_address" {
+  type = string
+}
+
+variable "smtp_port" {
+  type = string
+}
+
+variable "smtp_domain" {
+  type = string
+}
+
+variable "smtp_username" {
+  description = "SES SMTPユーザー名（globalスタックの ses_smtp_username 出力。アクセスキーIDなので非シークレット扱い）"
+  type        = string
+}

--- a/terraform/global/.terraform.lock.hcl
+++ b/terraform/global/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/global/backend.tf
+++ b/terraform/global/backend.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "logi-quiz-tfstate-438656921478"
+    key          = "global/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+
+  default_tags {
+    tags = {
+      Project   = "logi-quiz"
+      ManagedBy = "terraform"
+    }
+  }
+}

--- a/terraform/global/main.tf
+++ b/terraform/global/main.tf
@@ -1,0 +1,219 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# ---- ECR（production/staging共用。SHAタグでイメージを共有） ----
+
+resource "aws_ecr_repository" "api" {
+  name                 = "logi-quiz-api"
+  image_tag_mutability = "MUTABLE" # latestタグ運用のため。SHAタグは実質イミュータブル
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep last 10 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+# ---- SES（production/staging共用のドメインID。DKIM検証レコードはRoute53へ自動登録） ----
+
+data "aws_route53_zone" "main" {
+  name = "logi-quiz.com"
+}
+
+resource "aws_sesv2_email_identity" "domain" {
+  email_identity = "logi-quiz.com"
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  count = 3
+
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "${aws_sesv2_email_identity.domain.dkim_signing_attributes[0].tokens[count.index]}._domainkey.logi-quiz.com"
+  type    = "CNAME"
+  ttl     = 600
+  records = ["${aws_sesv2_email_identity.domain.dkim_signing_attributes[0].tokens[count.index]}.dkim.amazonses.com"]
+}
+
+# DMARC（p=none: まず監視のみ。DKIM alignmentで判定される）
+resource "aws_route53_record" "dmarc" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_dmarc.logi-quiz.com"
+  type    = "TXT"
+  ttl     = 600
+  records = ["v=DMARC1; p=none;"]
+}
+
+# SES SMTP認証用IAMユーザー。SMTPパスワードはアクセスキーのシークレットから導出される
+# （ses_smtp_password_v4）。tfstateに含まれるトレードオフはDBパスワードと同じ（§1.3）。
+resource "aws_iam_user" "ses_smtp" {
+  name = "logi-quiz-ses-smtp"
+}
+
+data "aws_iam_policy_document" "ses_send" {
+  statement {
+    actions   = ["ses:SendEmail", "ses:SendRawEmail"]
+    resources = [aws_sesv2_email_identity.domain.arn]
+  }
+}
+
+resource "aws_iam_user_policy" "ses_send" {
+  name   = "ses-send"
+  user   = aws_iam_user.ses_smtp.name
+  policy = data.aws_iam_policy_document.ses_send.json
+}
+
+resource "aws_iam_access_key" "ses_smtp" {
+  user = aws_iam_user.ses_smtp.name
+}
+
+# ---- GitHub Actions OIDC（長期アクセスキーを排除） ----
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # AWSはGitHubのOIDCでthumbprintを実際には検証しないが、引数として必須
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_policy_document" "github_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:SomaTomita/logi-quiz:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_deploy" {
+  name               = "logi-quiz-github-deploy"
+  assume_role_policy = data.aws_iam_policy_document.github_assume.json
+}
+
+data "aws_iam_policy_document" "deploy" {
+  statement {
+    sid       = "EcrAuth"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EcrPush"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+    ]
+    resources = [aws_ecr_repository.api.arn]
+  }
+
+  statement {
+    sid = "EcsReadRegister"
+    # Describe/Registerはリソースレベル制限が効かないアクション
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+      "ecs:DescribeServices",
+      "ecs:DescribeTasks",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EcsDeploy"
+    actions = [
+      "ecs:UpdateService",
+      "ecs:RunTask",
+    ]
+    resources = [
+      "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:service/logi-quiz-*",
+      "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task-definition/logi-quiz-*:*",
+    ]
+  }
+
+  statement {
+    sid       = "PassTaskRoles"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/logi-quiz-*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid = "FrontendSync"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "arn:aws:s3:::logi-quiz-frontend-*",
+      "arn:aws:s3:::logi-quiz-frontend-*/*",
+    ]
+  }
+
+  statement {
+    sid = "CloudFrontInvalidate"
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "deploy" {
+  name   = "deploy"
+  role   = aws_iam_role.github_deploy.id
+  policy = data.aws_iam_policy_document.deploy.json
+}

--- a/terraform/global/main.tf
+++ b/terraform/global/main.tf
@@ -1,5 +1,11 @@
 data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+
+locals {
+  # production（東京）とstaging（シンガポール）でリージョンが異なるため、
+  # data.aws_region.current（globalスタック自身のリージョン=ap-northeast-1）は使わず、
+  # デプロイ対象の2リージョンを明示する。
+  deploy_regions = ["ap-northeast-1", "ap-southeast-1"]
+}
 
 # ---- ECR（production/staging共用。SHAタグでイメージを共有） ----
 
@@ -170,10 +176,13 @@ data "aws_iam_policy_document" "deploy" {
       "ecs:UpdateService",
       "ecs:RunTask",
     ]
-    resources = [
-      "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:service/logi-quiz-*",
-      "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task-definition/logi-quiz-*:*",
-    ]
+    # production（ap-northeast-1）とstaging（ap-southeast-1）の両方を許可する
+    resources = flatten([
+      for r in local.deploy_regions : [
+        "arn:aws:ecs:${r}:${data.aws_caller_identity.current.account_id}:service/logi-quiz-*",
+        "arn:aws:ecs:${r}:${data.aws_caller_identity.current.account_id}:task-definition/logi-quiz-*:*",
+      ]
+    ])
   }
 
   statement {

--- a/terraform/global/outputs.tf
+++ b/terraform/global/outputs.tf
@@ -1,0 +1,16 @@
+output "ecr_repository_url" {
+  value = aws_ecr_repository.api.repository_url
+}
+
+output "github_deploy_role_arn" {
+  value = aws_iam_role.github_deploy.arn
+}
+
+output "ses_smtp_username" {
+  value = aws_iam_access_key.ses_smtp.id
+}
+
+output "ses_smtp_password" {
+  value     = aws_iam_access_key.ses_smtp.ses_smtp_password_v4
+  sensitive = true
+}

--- a/terraform/modules/alb_api/.terraform.lock.hcl
+++ b/terraform/modules/alb_api/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/modules/alb_api/main.tf
+++ b/terraform/modules/alb_api/main.tf
@@ -1,0 +1,105 @@
+data "aws_route53_zone" "this" {
+  name = var.route53_zone_name
+}
+
+resource "aws_acm_certificate" "this" {
+  domain_name       = var.api_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# 同一ドメインの検証CNAMEは名前も値も安定しているため、
+# 旧証明書の検証レコードが既に存在してもallow_overwriteで安全に共存できる。
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.this.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 300
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+}
+
+resource "aws_lb" "this" {
+  name               = "${var.name_prefix}-alb"
+  load_balancer_type = "application"
+  security_groups    = [var.security_group_id]
+  subnets            = var.subnet_ids
+}
+
+# nginxサイドカー廃止に伴い、ALBからPuma(:3000)へ直接フォワードする
+resource "aws_lb_target_group" "api" {
+  name                 = "${var.name_prefix}-api"
+  port                 = 3000
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 30
+
+  health_check {
+    path                = var.health_check_path
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate_validation.this.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+resource "aws_route53_record" "api" {
+  count = var.enable_dns_record ? 1 : 0
+
+  zone_id         = data.aws_route53_zone.this.zone_id
+  name            = var.api_domain_name
+  type            = "A"
+  allow_overwrite = true # 旧インフラのレコードをカットオーバーで上書きする
+
+  alias {
+    name                   = aws_lb.this.dns_name
+    zone_id                = aws_lb.this.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/modules/alb_api/outputs.tf
+++ b/terraform/modules/alb_api/outputs.tf
@@ -1,0 +1,12 @@
+output "target_group_arn" {
+  value = aws_lb_target_group.api.arn
+}
+
+output "alb_dns_name" {
+  value = aws_lb.this.dns_name
+}
+
+output "https_listener_arn" {
+  description = "スモークテストやリスナールール追加時の参照用（env側はmodule単位のdepends_onでリスナー作成を待つ）"
+  value       = aws_lb_listener.https.arn
+}

--- a/terraform/modules/alb_api/variables.tf
+++ b/terraform/modules/alb_api/variables.tf
@@ -1,0 +1,36 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "security_group_id" {
+  type = string
+}
+
+variable "api_domain_name" {
+  description = "例: api.logi-quiz.com"
+  type        = string
+}
+
+variable "route53_zone_name" {
+  description = "例: logi-quiz.com"
+  type        = string
+}
+
+variable "enable_dns_record" {
+  description = "trueでapi_domain_nameのAレコードをこのALBに向ける（カットオーバー用スイッチ）"
+  type        = bool
+  default     = false
+}
+
+variable "health_check_path" {
+  type    = string
+  default = "/health"
+}

--- a/terraform/modules/alb_api/versions.tf
+++ b/terraform/modules/alb_api/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/app_secrets/.terraform.lock.hcl
+++ b/terraform/modules/app_secrets/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/modules/app_secrets/main.tf
+++ b/terraform/modules/app_secrets/main.tf
@@ -1,0 +1,12 @@
+# 値はTerraform外（aws secretsmanager put-secret-value）で投入する。
+# tfstateに秘密値を残さないための意図的な設計。
+
+resource "aws_secretsmanager_secret" "secret_key_base" {
+  name                    = "${var.name_prefix}/SECRET_KEY_BASE"
+  recovery_window_in_days = var.recovery_window_in_days
+}
+
+resource "aws_secretsmanager_secret" "email_password" {
+  name                    = "${var.name_prefix}/EMAIL_PASSWORD"
+  recovery_window_in_days = var.recovery_window_in_days
+}

--- a/terraform/modules/app_secrets/outputs.tf
+++ b/terraform/modules/app_secrets/outputs.tf
@@ -1,0 +1,7 @@
+output "secret_key_base_arn" {
+  value = aws_secretsmanager_secret.secret_key_base.arn
+}
+
+output "email_password_arn" {
+  value = aws_secretsmanager_secret.email_password.arn
+}

--- a/terraform/modules/app_secrets/variables.tf
+++ b/terraform/modules/app_secrets/variables.tf
@@ -1,0 +1,9 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "recovery_window_in_days" {
+  description = "削除猶予日数。stagingは0（即時削除→再作成可能に）"
+  type        = number
+  default     = 7
+}

--- a/terraform/modules/app_secrets/versions.tf
+++ b/terraform/modules/app_secrets/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/ecs_service/.terraform.lock.hcl
+++ b/terraform/modules/ecs_service/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -1,0 +1,172 @@
+resource "aws_ecs_cluster" "this" {
+  name = var.name_prefix
+
+  setting {
+    # Container Insightsは追加コストがかかるためNFR（コスト）判断で無効
+    name  = "containerInsights"
+    value = "disabled"
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name       = aws_ecs_cluster.this.name
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name_prefix}"
+  retention_in_days = var.log_retention_days
+}
+
+data "aws_iam_policy_document" "ecs_tasks_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${var.name_prefix}-ecs-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "read_secrets" {
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = var.secret_arns
+  }
+}
+
+resource "aws_iam_role_policy" "execution_secrets" {
+  name   = "read-app-secrets"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.read_secrets.json
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name_prefix}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+}
+
+locals {
+  container_environment = [
+    for k, v in var.container_env : { name = k, value = v }
+  ]
+
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.this.name
+      awslogs-region        = var.region
+      awslogs-stream-prefix = "rails"
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "${var.name_prefix}-api"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "rails"
+      image     = var.image
+      essential = true
+      portMappings = [
+        { containerPort = 3000, protocol = "tcp" }
+      ]
+      environment = local.container_environment
+      secrets     = var.container_secrets
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+      logConfiguration = local.log_configuration
+    }
+  ])
+}
+
+# デプロイパイプラインがrun-taskで使うマイグレーション専用タスク定義。
+# サービスにはぶら下がらない（one-off実行専用）。
+resource "aws_ecs_task_definition" "migrate" {
+  family                   = "${var.name_prefix}-migrate"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name        = "migrate"
+      image       = var.image
+      essential   = true
+      command     = ["bundle", "exec", "rails", "db:migrate"]
+      environment = local.container_environment
+      secrets     = var.container_secrets
+      logConfiguration = merge(local.log_configuration, {
+        options = merge(local.log_configuration.options, { awslogs-stream-prefix = "migrate" })
+      })
+    }
+  ])
+}
+
+resource "aws_ecs_service" "api" {
+  name            = "${var.name_prefix}-api"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.desired_count
+
+  launch_type = var.use_fargate_spot ? null : "FARGATE"
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.use_fargate_spot ? [1] : []
+    content {
+      capacity_provider = "FARGATE_SPOT"
+      weight            = 1
+    }
+  }
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [var.security_group_id]
+    assign_public_ip = true # NAT/VPCエンドポイント不使用のため（ECR/Secretsへの経路）
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = "rails"
+    container_port   = 3000
+  }
+
+  lifecycle {
+    # アプリデプロイはGHAが新revisionを登録してサービスを更新する。
+    # Terraform側でcontainer_env等を変えた場合は、apply後にデプロイワークフローを
+    # 手動実行（workflow_dispatch）して新revisionを反映させること。
+    ignore_changes = [task_definition]
+  }
+
+  # capacity provider関連付け前にserviceが作られるとFARGATE_SPOT指定が失敗するため明示
+  depends_on = [aws_ecs_cluster_capacity_providers.this]
+}

--- a/terraform/modules/ecs_service/outputs.tf
+++ b/terraform/modules/ecs_service/outputs.tf
@@ -1,0 +1,15 @@
+output "cluster_name" {
+  value = aws_ecs_cluster.this.name
+}
+
+output "service_name" {
+  value = aws_ecs_service.api.name
+}
+
+output "api_task_family" {
+  value = aws_ecs_task_definition.api.family
+}
+
+output "migrate_task_family" {
+  value = aws_ecs_task_definition.migrate.family
+}

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -1,0 +1,73 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "image" {
+  description = "コンテナイメージ（ECR URL + タグ）。初回apply用。以降のデプロイはGHAがrevision更新する"
+  type        = string
+}
+
+variable "cpu" {
+  type    = string
+  default = "512"
+}
+
+variable "memory" {
+  type    = string
+  default = "1024"
+}
+
+variable "desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "use_fargate_spot" {
+  description = "trueでFARGATE_SPOTを使用（staging向け。中断耐性が必要なprodではfalse）"
+  type        = bool
+  default     = false
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "security_group_id" {
+  type = string
+}
+
+variable "target_group_arn" {
+  type = string
+}
+
+variable "container_env" {
+  description = "railsコンテナのプレーン環境変数"
+  type        = map(string)
+}
+
+variable "container_secrets" {
+  description = "Secrets Manager参照 [{name, valueFrom}]"
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+}
+
+variable "secret_arns" {
+  description = "実行ロールにGetSecretValueを許可するSecretのARN一覧"
+  type        = list(string)
+}
+
+variable "log_retention_days" {
+  type    = number
+  default = 30
+}
+
+variable "health_check_grace_period_seconds" {
+  type    = number
+  default = 60
+}

--- a/terraform/modules/ecs_service/versions.tf
+++ b/terraform/modules/ecs_service/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/frontend/.terraform.lock.hcl
+++ b/terraform/modules/frontend/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/modules/frontend/main.tf
+++ b/terraform/modules/frontend/main.tf
@@ -1,0 +1,175 @@
+data "aws_route53_zone" "this" {
+  name = var.route53_zone_name
+}
+
+# CloudFrontのviewer certificateはus-east-1のACMのみ使用可能
+resource "aws_acm_certificate" "this" {
+  provider          = aws.us_east_1
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.this.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 300
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "this" {
+  name                              = var.name_prefix
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# vercel.jsonのheaders設定の移植 + HSTS/Referrer-Policy追加
+resource "aws_cloudfront_response_headers_policy" "security" {
+  name = "${var.name_prefix}-security-headers"
+
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+    }
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = [var.domain_name]
+  price_class         = "PriceClass_200" # 日本を含むアジア/北米/欧州。All（南米等含む）は不要
+  comment             = var.name_prefix
+
+  origin {
+    domain_name              = aws_s3_bucket.this.bucket_regional_domain_name
+    origin_id                = "s3-frontend"
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.id
+  }
+
+  default_cache_behavior {
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+    target_origin_id           = "s3-frontend"
+    viewer_protocol_policy     = "redirect-to-https"
+    compress                   = true
+    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6" # AWS Managed: CachingOptimized
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
+  }
+
+  # vercel.jsonのSPA rewriteの移植: 存在しないパスはindex.htmlへ（React Routerが処理）
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.this.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.this.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.bucket_policy.json
+}
+
+resource "aws_route53_record" "this" {
+  count = var.enable_dns_record ? 1 : 0
+
+  zone_id         = data.aws_route53_zone.this.zone_id
+  name            = var.domain_name
+  type            = "A"
+  allow_overwrite = true # Vercel向けの既存レコードをカットオーバーで上書きする
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/modules/frontend/outputs.tf
+++ b/terraform/modules/frontend/outputs.tf
@@ -1,0 +1,11 @@
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}
+
+output "distribution_id" {
+  value = aws_cloudfront_distribution.this.id
+}
+
+output "distribution_domain_name" {
+  value = aws_cloudfront_distribution.this.domain_name
+}

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -1,0 +1,23 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "bucket_name" {
+  description = "例: logi-quiz-frontend-production-<account_id>"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "例: logi-quiz.com / staging.logi-quiz.com"
+  type        = string
+}
+
+variable "route53_zone_name" {
+  type = string
+}
+
+variable "enable_dns_record" {
+  description = "trueでdomain_nameのAレコードをCloudFrontに向ける（カットオーバー用スイッチ）"
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/frontend/versions.tf
+++ b/terraform/modules/frontend/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 6.0"
+      configuration_aliases = [aws.us_east_1]
+    }
+  }
+}

--- a/terraform/modules/network/.terraform.lock.hcl
+++ b/terraform/modules/network/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,0 +1,143 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.name_prefix}-vpc" }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = { Name = "${var.name_prefix}-igw" }
+}
+
+# NFR（コスト）によりパブリックサブネットのみ。ECSタスクはpublic IPでECR/Secretsに到達し、
+# RDSはpublicly_accessible=false + SGで保護する。本格運用ではprivate subnet + NATへ移行する。
+resource "aws_subnet" "public" {
+  count = length(var.availability_zones)
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "${var.name_prefix}-public-${var.availability_zones[count.index]}" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = { Name = "${var.name_prefix}-public" }
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "alb" {
+  name_prefix = "${var.name_prefix}-alb-"
+  description = "ALB: allow HTTP/HTTPS from internet"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "HTTP (redirect to HTTPS)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "${var.name_prefix}-alb" }
+}
+
+resource "aws_security_group" "app" {
+  name_prefix = "${var.name_prefix}-app-"
+  description = "ECS tasks: allow 3000 from ALB only"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "Rails from ALB"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "${var.name_prefix}-app" }
+}
+
+resource "aws_security_group" "rds" {
+  name_prefix = "${var.name_prefix}-rds-"
+  description = "RDS: allow 3306 from ECS tasks only"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "MySQL from app"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  dynamic "ingress" {
+    for_each = var.db_maintenance_ingress_cidrs
+    content {
+      description = "TEMPORARY maintenance access"
+      from_port   = 3306
+      to_port     = 3306
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "${var.name_prefix}-rds" }
+}

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "alb_security_group_id" {
+  value = aws_security_group.alb.id
+}
+
+output "app_security_group_id" {
+  value = aws_security_group.app.id
+}
+
+output "rds_security_group_id" {
+  value = aws_security_group.rds.id
+}

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,0 +1,20 @@
+variable "name_prefix" {
+  description = "リソース名プレフィックス（例: logi-quiz-production）"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+variable "db_maintenance_ingress_cidrs" {
+  description = "DB移行・メンテナンス作業時のみ一時的に3306を許可するCIDR。通常は空にすること"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/modules/network/versions.tf
+++ b/terraform/modules/network/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/rds/.terraform.lock.hcl
+++ b/terraform/modules/rds/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,75 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name_prefix}-mysql"
+  subnet_ids = var.subnet_ids
+
+  tags = { Name = "${var.name_prefix}-mysql" }
+}
+
+resource "aws_db_parameter_group" "this" {
+  name_prefix = "${var.name_prefix}-mysql80-"
+  family      = "mysql8.0"
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "collation_server"
+    value = "utf8mb4_unicode_ci"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# パスワードはTerraformが生成・Secrets Managerに保存し、ローテーションしない。
+# tfstateに値が含まれるトレードオフは §1.3 参照（stateバケットは暗号化・非公開）。
+resource "random_password" "master" {
+  length  = 32
+  special = false # MySQL接続文字列・CLIでのエスケープ事故を避ける
+}
+
+resource "aws_secretsmanager_secret" "db_password" {
+  name                    = "${var.name_prefix}/DATABASE_PASSWORD"
+  recovery_window_in_days = var.password_recovery_window_in_days
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id     = aws_secretsmanager_secret.db_password.id
+  secret_string = random_password.master.result
+}
+
+resource "aws_db_instance" "this" {
+  identifier     = "${var.name_prefix}-mysql"
+  engine         = "mysql"
+  engine_version = "8.0"
+  instance_class = var.instance_class
+
+  db_name  = var.db_name
+  username = var.master_username
+  password = random_password.master.result
+  port     = 3306
+
+  allocated_storage     = 20
+  max_allocated_storage = 50
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [var.security_group_id]
+  parameter_group_name   = aws_db_parameter_group.this.name
+  publicly_accessible    = var.publicly_accessible
+  multi_az               = var.multi_az
+
+  backup_retention_period    = var.backup_retention_period
+  auto_minor_version_upgrade = true
+  apply_immediately          = true
+
+  skip_final_snapshot       = var.skip_final_snapshot
+  final_snapshot_identifier = var.skip_final_snapshot ? null : "${var.name_prefix}-mysql-final"
+  deletion_protection       = var.deletion_protection
+
+  tags = { Name = "${var.name_prefix}-mysql" }
+}

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,16 @@
+output "address" {
+  value = aws_db_instance.this.address
+}
+
+output "db_name" {
+  value = aws_db_instance.this.db_name
+}
+
+output "master_username" {
+  value = aws_db_instance.this.username
+}
+
+output "db_password_secret_arn" {
+  description = "マスターパスワードのSecret。SecretStringはパスワード文字列そのもの（JSONではない）"
+  value       = aws_secretsmanager_secret.db_password.arn
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,59 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "password_recovery_window_in_days" {
+  description = "パスワードSecret削除時の猶予日数。stagingは0（destroy→再applyの名前衝突回避）"
+  type        = number
+  default     = 7
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "security_group_id" {
+  type = string
+}
+
+variable "db_name" {
+  description = "作成するデータベース名（現行と同一にしてdump/restoreを単純化する）"
+  type        = string
+}
+
+variable "master_username" {
+  type    = string
+  default = "admin"
+}
+
+variable "instance_class" {
+  type    = string
+  default = "db.t4g.micro"
+}
+
+variable "multi_az" {
+  type    = bool
+  default = false
+}
+
+variable "publicly_accessible" {
+  description = "DB移行作業時のみtrue。通常はfalse"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_period" {
+  description = "自動バックアップ保持日数。0で無効（stagingのみ）"
+  type        = number
+  default     = 7
+}
+
+variable "skip_final_snapshot" {
+  type    = bool
+  default = false
+}
+
+variable "deletion_protection" {
+  type    = bool
+  default = true
+}

--- a/terraform/modules/rds/versions.tf
+++ b/terraform/modules/rds/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}


### PR DESCRIPTION
Closes #105

## 変更内容（3秒で読める要約）

Terraformでbootstrap/global/modules（network, rds, app_secrets, alb_api, ecs_service, frontend）/envs（production=東京, staging=シンガポール）一式を追加。実際のAWS apply/planは含まない（コード作成+オフライン検証のみ）。

## 確認方法

- [x] `terraform/` 配下に bootstrap, global, modules/{network,rds,app_secrets,alb_api,ecs_service,frontend}, envs/{production,staging} が揃っている
- [x] 各ディレクトリで `terraform fmt -check` / `terraform init -backend=false && terraform validate` がエラーなく通る（frontendモジュール単体を除く。configuration_aliasesの構造上の制約でenvsレベルで検証済み）
- [x] `terraform apply` / `terraform plan` は未実行