### PR TITLE
fix: add retry to front service yarn install at container start (#106)

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,7 +24,14 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    command: sh -c "yarn install --frozen-lockfile && yarn dev"
+    # npmレジストリの一時的な取りこぼしでyarn installがハードフェイルすることがあるためリトライを入れる
+    command: >
+      sh -c "
+        (yarn install --frozen-lockfile --network-timeout 600000 ||
+         yarn install --frozen-lockfile --network-timeout 600000 ||
+         yarn install --frozen-lockfile --network-timeout 600000) &&
+        yarn dev
+      "
     volumes:
       - ./frontend/app:/front:cached
       - node-modules-volume:/front/node_modules


### PR DESCRIPTION
Closes #106

## 変更内容（3秒で読める要約）

前回のPR #107はDockerfileのビルド時 `yarn install` のみ修正しており、docker-compose.override.ymlのfrontサービス起動コマンドが別途実行する `yarn install --frozen-lockfile`（node-modules-volumeとの同期用）にはリトライが入っていなかった。同じリトライ+timeout延長を追加。

## 確認方法

- [x] `docker compose config front` でYAML構文が正しくパースされる
- [x] `docker compose run --rm --no-deps front sh -c "yarn install --frozen-lockfile --network-timeout 600000"` が成功する